### PR TITLE
added OrderChangesData to SubscriptionData

### DIFF
--- a/src/models/internal.rs
+++ b/src/models/internal.rs
@@ -1,7 +1,7 @@
 use super::subscription::{
     AnnouncementsData, BookData, DeribitPriceIndexData, DeribitPriceRankingData,
     EstimatedExpirationPriceData, GroupedBookData, MarkPriceOptionData, PerpetualData, QuoteData,
-    TickerData, TradesData, UserOrdersData, UserPortfolioData, UserTradesData,
+    TickerData, TradesData, UserOrdersData, UserPortfolioData, UserTradesData, UserChangesData,
 };
 use crate::models::{Either, Request};
 use serde::{Deserialize, Serialize};
@@ -113,6 +113,7 @@ pub enum SubscriptionData {
     Perpetual(PerpetualData),
     Ticker(TickerData),
     Quote(QuoteData), // This should be put after Ticker otherwise all Tickers will be deserialized to Quotes
+    UserChanges(UserChangesData),
     UserOrders(UserOrdersData),
     UserOrdersBatch(Vec<UserOrdersData>),
     UserPortfolio(UserPortfolioData),

--- a/src/models/subscription.rs
+++ b/src/models/subscription.rs
@@ -14,6 +14,7 @@ pub use channels::TradesData;
 pub use channels::UserOrdersData;
 pub use channels::UserPortfolioData;
 pub use channels::UserTradesData;
+pub use channels::UserChangesData;
 pub use channels::{BookData, Delta, GroupedBookData, OrderBookDelta};
 pub use channels::{Greeks, Stats, TickerData};
 

--- a/src/models/subscription/channels.rs
+++ b/src/models/subscription/channels.rs
@@ -11,6 +11,7 @@ mod trades;
 mod user_orders;
 mod user_portfolio;
 mod user_trades;
+mod user_changes;
 
 pub use announcements::AnnouncementsData;
 pub use book::{BookData, Delta, GroupedBookData, OrderBookDelta};
@@ -25,3 +26,4 @@ pub use trades::TradesData;
 pub use user_orders::UserOrdersData;
 pub use user_portfolio::UserPortfolioData;
 pub use user_trades::UserTradesData;
+pub use user_changes::UserChangesData;

--- a/src/models/subscription/channels/user_changes.rs
+++ b/src/models/subscription/channels/user_changes.rs
@@ -1,0 +1,38 @@
+use serde::{Deserialize, Serialize};
+use crate::models::subscription::{UserOrdersData, UserTradesData};
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct UserChangesData {
+    instrument_name: String,
+    orders: Vec<UserOrdersData>,
+    positions: Vec<Position>,
+    trades: Vec<UserTradesData>
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct Position {
+    average_price: f64,
+    average_price_usd: Option<f64>,
+    delta: f64,
+    direction: String,
+    estimated_liquidation_price: Option<f64>,
+    floating_profit_loss: f64,
+    floating_profit_loss_usd: f64,
+    gamma: Option<f64>,
+    index_price: f64,
+    initial_margin: f64,
+    instrument_name: String,
+    kind: String,
+    leverage: i64,
+    maintenance_margin: f64,
+    mark_price: f64,
+    open_orders_margin: f64,
+    realized_funding: Option<f64>,
+    realized_profit_loss: f64,
+    settlement_price: f64,
+    size: f64,
+    size_currency: Option<f64>,
+    theta: Option<f64>,
+    total_profit_loss: f64,
+    vega: Option<f64>,
+}


### PR DESCRIPTION
This allows for the private subscription to user.changes.{instrument_name}.{interval} and user.changes.{kind}.{currency}.{interval}. As far as I know this was currently not possible but it was needed for my project as otherwise there is no way to subscribe to position updates which are included in user.changes. It works nicely in my production trading bot but in the futures I may add it to a test just to have it tested formally. I hope this PR is useful and thanks for the great library dovahcrow!