### PR TITLE
BookChannel fields must be pub, otherwise SubscriptionData::Book

### DIFF
--- a/src/models/subscription/channels/book.rs
+++ b/src/models/subscription/channels/book.rs
@@ -26,7 +26,7 @@ pub struct BookData {
 }
 
 #[derive(Debug, Clone)]
-pub struct BookChannel(String, String);
+pub struct BookChannel(pub String, pub String);
 impl<'de> Deserialize<'de> for BookChannel {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where


### PR DESCRIPTION
channel.0 and channel.1 fields of `book` object, that is returned by SubscriptionData::Book must be readable