### PR TITLE
Deribit price ranking subscription updates

### DIFF
--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -24,7 +24,7 @@ pub use jsonrpc::{JSONRPCRequest, JSONRPCResponse, JSONRPCVersion};
 pub use market_data::{
     GetBookSummaryByCurrencyRequest, GetBookSummaryByCurrencyResponse, GetFundingRateValueRequest,
     GetFundingRateValueResponse, GetIndexRequest, GetIndexResponse, GetInstrumentsRequest,
-    GetInstrumentsResponse, GetOrderBookRequest, GetOrderBookResponse
+    GetInstrumentsResponse, GetOrderBookRequest, GetOrderBookResponse,
 };
 pub use session_management::{
     CancelOnDisconnectScope, DisableCancelOnDisconnectRequest, DisableCancelOnDisconnectResponse,
@@ -182,6 +182,13 @@ pub enum OrderState {
     Cancelled,
     Untriggered,
     Archive,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum OrderBookState {
+    Open,
+    Closed,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq)]

--- a/src/models/subscription/channels/deribit_price_ranking.rs
+++ b/src/models/subscription/channels/deribit_price_ranking.rs
@@ -8,13 +8,14 @@ use serde::{
 pub struct DeribitPriceRankingData {
     pub enabled: bool,
     pub identifier: String,
+    pub original_price: f64,
     pub price: f64,
     pub timestamp: u64,
     pub weight: f64,
 }
 
 #[derive(Debug, Clone)]
-pub struct DeribitPriceRankingChannel(String);
+pub struct DeribitPriceRankingChannel(pub String);
 impl<'de> Deserialize<'de> for DeribitPriceRankingChannel {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/models/subscription/channels/ticker.rs
+++ b/src/models/subscription/channels/ticker.rs
@@ -1,4 +1,4 @@
-use crate::models::OrderState;
+use crate::models::OrderBookState;
 use fehler::throw;
 use serde::{
     de::{Error, Unexpected},
@@ -18,6 +18,7 @@ pub struct TickerData {
     pub bid_iv: Option<f64>,
     pub current_funding: Option<f64>,
     pub delivery_price: Option<f64>,
+    pub estimated_delivery_price: f64,
     pub funding_8h: Option<f64>,
     pub greeks: Option<Greeks>,
     pub index_price: f64,
@@ -30,7 +31,7 @@ pub struct TickerData {
     pub min_price: f64,
     pub open_interest: f64,
     pub settlement_price: Option<f64>,
-    pub state: OrderState,
+    pub state: OrderBookState,
     pub stats: Stats,
     pub timestamp: u64,
     pub underlying_index: Option<String>,
@@ -51,6 +52,7 @@ pub struct Stats {
     pub high: Option<f64>,
     pub low: Option<f64>,
     pub volume: Option<f64>,
+    pub volume_usd: Option<f64>,
     pub price_change: Option<f64>,
 }
 


### PR DESCRIPTION
I've enhanced few structs, related to `deribit_price_ranking` and `ticker.*` subscriptions. Unfortunatel I could not really find in Deribit API changelog, when these changes have been introduced.

1. updated `DeribitPriceRanking` structures:
 - `DeribitPriceRankingChannel.0` (channel name) should be public
 - added `DeribitPriceRankingData.original_price`
 
2. updated `TickerData`:
- `state` - changed type, enum with two values ("open, "close") should be used here - added OrderBookState, see [doc](https://docs.deribit.com/#ticker-instrument_name-interval)
- added `estimated_delivery_price` field
- added `Stats. volume_usd` - as it is present in subscription response