### PR TITLE
Update GetOrderBookResponse struct

### DIFF
--- a/src/models/market_data.rs
+++ b/src/models/market_data.rs
@@ -229,7 +229,7 @@ pub struct GetOrderBookResponse {
     state: State,
     stats: Stats,
     timestamp: u64,
-    underlying_index: Option<f64>,
+    underlying_index: Option<String>,
     underlying_price: Option<f64>
 }
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -101,8 +101,12 @@ impl std::str::FromStr for Currency {
 pub enum AssetKind {
     #[serde(alias = "future")]
     Future,
+    #[serde(alias = "future_combo")]
+    FutureCombo,
     #[serde(alias = "option")]
     Option,
+    #[serde(alias = "option_combo")]
+    OptionCombo,
 }
 
 impl std::str::FromStr for AssetKind {


### PR DESCRIPTION
Looks like the API has changed slightly as the `get_order_book` method now returns a String in the underlying_index field.
![image](https://user-images.githubusercontent.com/36125468/212566423-f4a9b75c-2054-401f-b2f4-6b401d736955.png)
