### PR TITLE
WIP: Add public/get_last_trades_by_currency method, allow for pagination results

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ while let Some(message) = subscription.next().await {
     - [x] /public/get_instruments
     - [ ] /public/get_last_settlements_by_currency
     - [ ] /public/get_last_settlements_by_instrument
-    - [ ] /public/get_last_trades_by_currency
+    - [X] /public/get_last_trades_by_currency
     - [ ] /public/get_last_trades_by_currency_and_time
     - [ ] /public/get_last_trades_by_instrument
     - [ ] /public/get_last_trades_by_instrument_and_time

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -1,5 +1,5 @@
 use crate::errors::{DeribitError, Result};
-use crate::models::{JSONRPCRequest, JSONRPCResponse, Request};
+use crate::models::{JSONRPCRequest, JSONRPCResponse, Request, WithPagination};
 use crate::WSStream;
 use anyhow::Error;
 use fehler::throws;

--- a/src/models/jsonrpc.rs
+++ b/src/models/jsonrpc.rs
@@ -1,4 +1,4 @@
-use crate::models::{Either, Request};
+use crate::models::{Either, EitherWrapper, Request};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
@@ -16,7 +16,7 @@ pub struct JSONRPCResponse<R> {
     pub id: i64,
     pub testnet: bool,
     #[serde(alias = "error")]
-    pub result: Either<R, ErrorDetail>,
+    pub result: EitherWrapper<R, ErrorDetail>,
     pub us_in: u64,
     pub us_out: u64,
     pub us_diff: u64,

--- a/src/models/market_data.rs
+++ b/src/models/market_data.rs
@@ -1,4 +1,4 @@
-use crate::models::{AssetKind, Currency, Request};
+use crate::models::{AssetKind, Currency, Direction, Request, Sorting};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -245,4 +245,75 @@ pub enum State {
     Open,
     #[serde(alias = "closed")]
     Closed,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, Default)]
+pub struct GetLastTradesByCurrencyRequest {
+    pub currency: Currency,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<AssetKind>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub count: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub include_old: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sorting: Option<Sorting>,
+}
+
+impl GetLastTradesByCurrencyRequest {
+    pub fn new(currency: Currency) -> Self {
+        Self {
+            currency,
+            ..Default::default()
+        }
+    }
+
+    pub fn include_old(currency: Currency) -> Self {
+        Self {
+            currency,
+            include_old: Some(true),
+            ..Default::default()
+        }
+    }
+
+    pub fn futures(currency: Currency) -> Self {
+        Self::with_kind(currency, AssetKind::Future)
+    }
+
+    pub fn options(currency: Currency) -> Self {
+        Self::with_kind(currency, AssetKind::Option)
+    }
+
+    pub fn with_kind(currency: Currency, kind: AssetKind) -> Self {
+        Self {
+            currency,
+            kind: Some(kind),
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct GetLastTradesByCurrencyResponse {
+    pub amount: Option<f64>,
+    pub block_trade_id: Option<String>,
+    pub direction: Direction,
+    pub index_price: f64,
+    pub instrument_name: String,
+    pub iv: Option<f64>,
+    pub mark_price: f64,
+    pub price: f64,
+    pub trade_id: String,
+    pub timestamp: u64,
+    pub trade_seq: u64,
+    pub tick_direction: i64,
+}
+
+impl Request for GetLastTradesByCurrencyRequest {
+    const METHOD: &'static str = "public/get_last_trades_by_currency";
+    type Response = Vec<GetLastTradesByCurrencyResponse>;
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -362,6 +362,22 @@ impl<L, R> Either<L, R> {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WithPagination<L, R> {
+    #[serde(alias = "trades")]
+    pub values: Either<L, R>,
+    pub has_more: bool,
+}
+
+impl<L, R> WithPagination<L, R> {
+    pub fn left_result(self) -> StdResult<L, R> {
+        match self.values {
+            Either::Left(l) => Ok(l),
+            Either::Right(r) => Err(r),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Any3<O1, O2, O3> {
     First(O1),
@@ -484,4 +500,29 @@ pub enum Any12<O1, O2, O3, O4, O5, O6, O7, O8, O9, O10, O11, O12> {
     Tenth(O10),
     Eleventh(O11),
     Twelfth(O12),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Sorting {
+    #[serde(rename = "asc")]
+    Asc,
+    #[serde(rename = "default")]
+    Default,
+    #[serde(rename = "desc")]
+    Desc,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum EitherWrapper<L, R> {
+    with_pagination(WithPagination<L, R>),
+    no_pagination(Either<L, R>),
+}
+impl<L, R> EitherWrapper<L, R> {
+    pub fn left_result(self) -> StdResult<L, R> {
+        match self {
+            EitherWrapper::with_pagination(l) => l.left_result(),
+            EitherWrapper::no_pagination(r) => r.left_result(),
+        }
+    }
 }


### PR DESCRIPTION
Ok, so I was playing around with your library some more, tried to add the `get_last_trades_by_currency` method, but that didn't work on its own, as the "result" part of the json response actually has two parts - "trades" which has the collection of trades and has_more which is a bool.
Couldn't parse it w/ the existing helper enum, so had to write an object that wraps around **Either**..which uhm I don't like? I mean it works, I was able to make it run, but I'd say I'm still new-ish to Rust and it just isn't a solution I like right out of the gate, hence the WIP.

If I'm reading it correctly, Either is really the same object collections crate uses that you're using here so you can parse either the response or an error and propagate it back to the user?
Also I couldn't figure out what's the purpose of **Any** enums, looks like it's dead code? Thanks for writing this library, I think I'm getting the gist of the internals and I definitely learned a lot by reading the code and playing around w/ it!